### PR TITLE
convert node type to str for word2vec to work

### DIFF
--- a/libs/persona2vec/node2vec.py
+++ b/libs/persona2vec/node2vec.py
@@ -182,7 +182,7 @@ class Node2Vec(object):
             else:
                 break
 
-        return walk
+        return list(map(str, walk))
 
     def learn_embedding(self):
         """


### PR DESCRIPTION
Sometimes the nodes are represented with integers, this would break the word2vec implementation in gensim. Forcing all the elements in the walk list to string would fix this issue.