### PR TITLE
Implement a faster training testing split method

### DIFF
--- a/libs/persona2vec/network_train_test_splitter.py
+++ b/libs/persona2vec/network_train_test_splitter.py
@@ -56,6 +56,55 @@ class NetworkTrainTestSplitter(object):
                 else:
                     self.G.add_edge(source, target, weight=1)
 
+    def train_test_split_fast(self):
+        """
+        Split train and test edges.
+        Train network should have a one weakly connected component.
+        """
+        logging.info("Initiate train test set split")
+        if self.directed:
+            logging.error("Not implemented for directed graph")
+            return
+
+        while len(self.test_edges) != self.number_of_test_edges:
+            edge_list = np.array(self.G.edges())
+            candidate_idxs = np.random.choice(
+                len(edge_list),
+                self.number_of_test_edges - len(self.test_edges),
+                replace=False,
+            )
+            for source, target in tqdm(edge_list[candidate_idxs]):
+                # cases sure cannot remove the edge:
+                # one node is dangling
+                if self.G.degree(source) == 1 or self.G.degree(target) == 1:
+                    continue
+
+                self.G.remove_edge(source, target)
+                # cases sure can remove the edge:
+                # source is reachable for target through other nodes
+                # instead of using the default check connectivity method
+                # here we use a lazy BFS method to stop early if target is reachable
+                reachable = False
+                seen={}                  # level (number of hops) when seen in BFS
+                level=0                  # the current level
+                nextlevel={source:1}  # dict of nodes to check at next level
+                while nextlevel:
+                    thislevel=nextlevel  # advance to next level
+                    nextlevel={}         # and start a new list (fringe)
+                    for v in thislevel:
+                        if v not in seen:
+                            seen[v]=level # set the level of vertex v
+                            nextlevel.update(self.G[v]) # add neighbors of v
+                    if target in seen:
+                        reachable = True
+                        break
+                    level=level+1
+
+                if reachable:
+                    self.test_edges.append((source, target))
+                else:
+                    self.G.add_edge(source, target, weight=1)
+
     def generate_negative_edges(self):
         """
         Generate a negative samples for link prediction task


### PR DESCRIPTION
Instead of using the default networkx check connectivity function to check for every node, here we can only check if the two ends of the removed edge are still reachable with each other. If not, it means removing the edge breaks the network.
In the implementation, we can use a lazy BFS and stop early if we the two nodes are connected.

I had some rough tests, the new method is 4x faster on caHepTh, 10-20% faster on PPI. It seems the new implementation dose help with the splitting.

Disadvantage is that it only support undirected networks.