### PR TITLE
better negative edge sampling

### DIFF
--- a/libs/persona2vec/network_train_test_splitter.py
+++ b/libs/persona2vec/network_train_test_splitter.py
@@ -112,9 +112,7 @@ class NetworkTrainTestSplitter(object):
         logging.info("Initiate generating negative edges")
         while len(self.negative_edges) != self.number_of_test_edges:
             source, target = np.random.choice(self.node_list, 2)
-            if (source, target) in self.original_edge_set:
-                pass
-            else:
+            if (source, target) not in self.original_edge_set and (target, source) not in self.original_edge_set:
                 self.negative_edges.append((source, target))
 
     def save_splitted_result(self, path):


### PR DESCRIPTION
For undirected networks, G.edges only gives you (x, y), not (y, x). In order to make sure a randomly sample edge (u, m) is not really in the true edge set, we have to check both (u, m) and (m, u).

The original implementation would put some real edges in the negative set. I tested it with PPI, there is about 1-5%. Theoretically, after fixing this issue, the final AUC would go up a little bit for all models.